### PR TITLE
Fix double response in VATSIM API

### DIFF
--- a/src/pages/api/vatsim/online/[cid].ts
+++ b/src/pages/api/vatsim/online/[cid].ts
@@ -54,6 +54,7 @@ export default async function handler(
         roleData:
           controller.facility !== 0 ? controller.frequency : "Observing...",
       });
+      return;
     }
 
     const pilot: Pilot | undefined = dataFeedRes.data.pilots.find(
@@ -67,6 +68,7 @@ export default async function handler(
         role: "pilot",
         roleData: `${pilot.flight_plan.departure} - ${pilot.flight_plan.arrival}`,
       });
+      return;
     }
 
     res.status(200).json({


### PR DESCRIPTION
## Summary
- fix early returns in VATSIM online API to avoid sending multiple responses

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684058eb8b9c832fb18c0804aa998698