### PR TITLE
Fix missing date metadata for Cross the Pond post

### DIFF
--- a/data/posts/2024-04-20-cross-the-pond-westbound-2024.mdx
+++ b/data/posts/2024-04-20-cross-the-pond-westbound-2024.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cross the Pond Westbound 2024
+date: "2024-04-20"
 tags:
   - Timelapse
   - Dutch VACC


### PR DESCRIPTION
## Summary
- add the missing `date` frontmatter to the "Cross the Pond Westbound 2024" post so it sorts correctly with newer entries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e374a0125c832f8b5810c968db018d